### PR TITLE
Fix providing client data from EventPayload to ButtonResponse

### DIFF
--- a/types.go
+++ b/types.go
@@ -193,6 +193,7 @@ type Part struct {
 
 func (ep *EventPayload) CallbackQuery() *ButtonResponse {
 	return &ButtonResponse{
+		client:       ep.client,
 		QueryID:      ep.QueryID,
 		CallbackData: ep.CallbackData,
 	}


### PR DESCRIPTION
Method Send() in ButtonResponse struct gets null pointer to client when you try to get ButtonResponse from  EventPayload.CallbackQuery()