### PR TITLE
Allow to send GET request to /chats/sendActions with empty actions list

### DIFF
--- a/api_mock.go
+++ b/api_mock.go
@@ -295,6 +295,17 @@ func (h *MockHandler) SelfGet(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (h *MockHandler) HandleActions(w http.ResponseWriter, r *http.Request) {
+	response := `{
+		"ok": true
+	}`
+
+	_, err := w.Write([]byte(response))
+	if err != nil {
+		h.logger.Fatal("failed to write actions response")
+	}
+}
+
 func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.FormValue("token") == "":
@@ -308,6 +319,9 @@ func (h *MockHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case r.URL.Path == "/self/get":
 		h.SelfGet(w, r)
+		return
+	case r.URL.Path == "/chats/sendActions":
+		h.HandleActions(w, r)
 		return
 	default:
 		encoder := json.NewEncoder(w)

--- a/bot.go
+++ b/bot.go
@@ -45,6 +45,11 @@ func (b *Bot) SendChatActions(chatID string, actions ...ChatAction) error {
 	return b.client.SendChatActions(chatID, actions...)
 }
 
+// SendChatNoAction sends an empty action to signal that all actions are done.
+func (b *Bot) SendChatNoAction(chatID string) error {
+	return b.client.SendChatNoAction(chatID)
+}
+
 // GetChatAdmins returns chat admins list with fields:
 // userID, creator flag
 func (b *Bot) GetChatAdmins(chatID string) ([]ChatMember, error) {

--- a/client.go
+++ b/client.go
@@ -171,6 +171,18 @@ func (c *Client) SendChatActions(chatID string, actions ...ChatAction) error {
 	return nil
 }
 
+func (c *Client) SendChatNoAction(chatID string) error {
+	params := url.Values{
+		"chatId":  {chatID},
+		"actions": {""},
+	}
+	_, err := c.Do("/chats/sendActions", params, nil)
+	if err != nil {
+		return fmt.Errorf("error while sending no action: %s", err)
+	}
+	return nil
+}
+
 func (c *Client) GetChatAdmins(chatID string) ([]ChatMember, error) {
 	params := url.Values{
 		"chatId": {chatID},

--- a/client_test.go
+++ b/client_test.go
@@ -312,3 +312,18 @@ func TestClient_GetInfo_Error(t *testing.T) {
 
 	require.NoError(nil)
 }
+
+func TestClient_SendChatNoAction(t *testing.T) {
+	testServer := httptest.NewServer(&MockHandler{})
+	defer func() { testServer.Close() }()
+
+	client := Client{
+		baseURL: testServer.URL,
+		token:   "test_token",
+		client:  http.DefaultClient,
+		logger:  &logrus.Logger{},
+	}
+
+	err := client.SendChatNoAction("chat_id")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
According to the [documentation](https://teams.vk.com/botapi/#/chats/get_chats_sendActions), if all actions are stopped, one needs to send a GET request to /chats/sendActions with an empty actions parameter. 

This PR adds a method to send an empty actions so signal that actions were stopped.

I suggest to do it as a separate method instead of changing signature of the `SendChatActions` method to keep the backward comparability.