### PR TITLE
Replaced os.File with an equivalent interface

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/sirupsen/logrus"
 )
@@ -69,7 +68,7 @@ func (b *Bot) GetChatAdmins(chatID string) ([]ChatMember, error) {
 	return b.client.GetChatAdmins(chatID)
 }
 
-// GetChatMem returns chat members list with fields:
+// GetChatMembers returns chat members list with fields:
 // userID, creator flag, admin flag
 func (b *Bot) GetChatMembers(chatID string) ([]ChatMember, error) {
 	return b.client.GetChatMembers(chatID)
@@ -187,7 +186,7 @@ func (b *Bot) NewDeeplinkMessage(chatID, text string, keyboard Keyboard, deeplin
 }
 
 // NewFileMessage returns new file message
-func (b *Bot) NewFileMessage(chatID string, file *os.File) *Message {
+func (b *Bot) NewFileMessage(chatID string, file UploadFile) *Message {
 	return &Message{
 		client:      b.client,
 		Chat:        Chat{ID: chatID},
@@ -207,7 +206,7 @@ func (b *Bot) NewFileMessageByFileID(chatID, fileID string) *Message {
 }
 
 // NewVoiceMessage returns new voice message
-func (b *Bot) NewVoiceMessage(chatID string, file *os.File) *Message {
+func (b *Bot) NewVoiceMessage(chatID string, file UploadFile) *Message {
 	return &Message{
 		client:      b.client,
 		Chat:        Chat{ID: chatID},

--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -22,11 +21,11 @@ type Client struct {
 	logger  *logrus.Logger
 }
 
-func (c *Client) Do(path string, params url.Values, file *os.File) ([]byte, error) {
+func (c *Client) Do(path string, params url.Values, file UploadFile) ([]byte, error) {
 	return c.DoWithContext(context.Background(), path, params, file)
 }
 
-func (c *Client) DoWithContext(ctx context.Context, path string, params url.Values, file *os.File) ([]byte, error) {
+func (c *Client) DoWithContext(ctx context.Context, path string, params url.Values, file UploadFile) ([]byte, error) {
 	apiURL, err := url.Parse(c.baseURL + path)
 	params.Set("token", c.token)
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,60 +1,36 @@
 package botgolang
 
 import (
-	"net/http"
-	"net/http/httptest"
+	"context"
 	"net/url"
+	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestClient_Do_OK(t *testing.T) {
-	assert := assert.New(t)
-	testServer := httptest.NewServer(&MockHandler{})
-	defer func() { testServer.Close() }()
-
-	client := Client{
-		baseURL: testServer.URL,
-		token:   "test_token",
-		client:  http.DefaultClient,
-		logger:  &logrus.Logger{},
-	}
+	client := NewApiMockClient(t)
 
 	bytes, err := client.Do("/", url.Values{}, nil)
 
-	assert.NoError(err)
-	assert.JSONEq(`{"ok":true}`, string(bytes))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, string(bytes))
 }
 
 func TestClient_Do_Error(t *testing.T) {
-	assert := assert.New(t)
-	testServer := httptest.NewServer(&MockHandler{})
-	defer func() { testServer.Close() }()
-
-	client := Client{
-		baseURL: testServer.URL,
-		token:   "",
-		client:  http.DefaultClient,
-		logger:  &logrus.Logger{},
-	}
+	client := NewApiMockClient(t)
+	client.token = "" // Clear token to trigger error
 
 	expected := `{"ok":false, "description":"Missing required parameter 'token'"}`
 
 	bytes, err := client.Do("/", url.Values{}, nil)
 
-	assert.EqualError(err, "error status from API: Missing required parameter 'token'")
-	assert.JSONEq(expected, string(bytes))
+	require.EqualError(t, err, "error status from API: Missing required parameter 'token'")
+	require.JSONEq(t, expected, string(bytes))
 }
 
 func TestClient_GetEvents_OK(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	testServer := httptest.NewServer(&MockHandler{})
-	defer func() { testServer.Close() }()
-
 	expected := []*Event{
 		{
 			EventID: 1,
@@ -276,39 +252,99 @@ func TestClient_GetEvents_OK(t *testing.T) {
 		},
 	}
 
-	client := Client{
-		baseURL: testServer.URL,
-		token:   "test_token",
-		client:  http.DefaultClient,
-		logger:  &logrus.Logger{},
-	}
+	client := NewApiMockClient(t)
 
 	events, err := client.GetEvents(0, 0)
 
-	require.NoError(err)
-	assert.Equal(events, expected)
+	require.NoError(t, err)
+	require.Equal(t, events, expected)
 }
 
 func TestClient_GetInfo_OK(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	testServer := httptest.NewServer(&MockHandler{})
-	defer func() { testServer.Close() }()
-
-	client := Client{
-		baseURL: testServer.URL,
-		token:   "test_token",
-		client:  http.DefaultClient,
-		logger:  &logrus.Logger{},
-	}
+	client := NewApiMockClient(t)
 
 	info, err := client.GetChatInfo("id_1234")
-	require.NoError(err)
-	assert.NotEmpty(info.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, info.ID)
 }
 
 func TestClient_GetInfo_Error(t *testing.T) {
 	require := require.New(t)
 
 	require.NoError(nil)
+}
+
+func TestClient_Do_WithFileUpload(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	content := strings.NewReader("test file content")
+	uploadFile := NewUploadFileFromReader("test.txt", content)
+
+	bytes, err := client.Do("/messages/sendFile", url.Values{}, uploadFile)
+
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true,"msgId":"test123","timestamp":123456}`, string(bytes))
+}
+
+func TestClient_DoWithContext_WithFileUpload(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	content := strings.NewReader("test voice content")
+	uploadFile := NewUploadFileFromReader("voice.ogg", content)
+
+	bytes, err := client.DoWithContext(context.Background(), "/messages/sendVoice", url.Values{}, uploadFile)
+
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true,"msgId":"voice123","timestamp":123456}`, string(bytes))
+}
+
+func TestClient_Do_WithEmptyFile_Error(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	content := strings.NewReader("")
+	uploadFile := NewUploadFileFromReader("empty.txt", content)
+
+	bytes, err := client.Do("/messages/sendFile", url.Values{}, uploadFile)
+
+	require.JSONEq(t, `{"ok":false,"description":"File cannot be empty"}`, string(bytes))
+	require.EqualError(t, err, "error status from API: File cannot be empty")
+}
+
+func TestClient_Do_GET_WithoutFileID_Error(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	bytes, err := client.Do("/messages/sendFile", url.Values{}, nil)
+
+	require.JSONEq(t, `{"ok":false,"description":"Missing required parameter 'fileId'"}`, string(bytes))
+	require.EqualError(t, err, "error status from API: Missing required parameter 'fileId'")
+}
+
+func TestClient_Do_SendVoice_Validation(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     UploadFile
+		expected string
+	}{
+		{
+			name:     "without_file",
+			file:     nil,
+			expected: `{"ok":false,"description":"Missing required parameter 'fileId'"}`,
+		},
+		{
+			name:     "with_empty_file",
+			file:     NewUploadFileFromReader("empty.ogg", strings.NewReader("")),
+			expected: `{"ok":false,"description":"File cannot be empty"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewApiMockClient(t)
+
+			bytes, err := client.Do("/messages/sendVoice", url.Values{}, tc.file)
+
+			require.JSONEq(t, tc.expected, string(bytes))
+			require.Error(t, err)
+		})
+	}
 }

--- a/file.go
+++ b/file.go
@@ -1,5 +1,7 @@
 package botgolang
 
+import "io"
+
 //go:generate easyjson -all file.go
 
 type File struct {
@@ -17,4 +19,29 @@ type File struct {
 
 	// URL to the file
 	URL string `json:"url"`
+}
+
+type Named interface {
+	Name() string
+}
+
+type UploadFile interface {
+	Named
+	io.Reader
+}
+
+type uploadReader struct {
+	io.Reader
+	name string
+}
+
+func (u uploadReader) Name() string {
+	return u.name
+}
+
+func NewUploadFileFromReader(name string, r io.Reader) UploadFile {
+	return uploadReader{
+		Reader: r,
+		name:   name,
+	}
 }

--- a/message.go
+++ b/message.go
@@ -2,7 +2,6 @@ package botgolang
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 )
 
@@ -27,7 +26,7 @@ type Message struct {
 	ID string `json:"msgId"`
 
 	// File contains file attachment of the message
-	File *os.File `json:"-"`
+	File UploadFile `json:"-"`
 
 	// Id of file to send
 	FileID string `json:"fileId"`
@@ -68,7 +67,7 @@ type Message struct {
 	Deeplink string `json:"deeplink"`
 }
 
-func (m *Message) AttachNewFile(file *os.File) {
+func (m *Message) AttachNewFile(file UploadFile) {
 	m.File = file
 	m.ContentType = OtherFile
 }
@@ -78,7 +77,7 @@ func (m *Message) AttachExistingFile(fileID string) {
 	m.ContentType = OtherFile
 }
 
-func (m *Message) AttachNewVoice(file *os.File) {
+func (m *Message) AttachNewVoice(file UploadFile) {
 	m.File = file
 	m.ContentType = Voice
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,374 @@
+package botgolang
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessage_AttachNewFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent string
+		fileName    string
+	}{
+		{
+			name:        "valid_file",
+			fileContent: "test content",
+			fileName:    "test.txt",
+		},
+		{
+			name:        "empty_file",
+			fileContent: "",
+			fileName:    "empty.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile, err := os.CreateTemp(tmpDir, tt.fileName)
+			t.Cleanup(func() {
+				err := tmpFile.Close()
+				assert.NoError(t, err)
+			})
+
+			require.NoError(t, err)
+
+			_, err = tmpFile.WriteString(tt.fileContent)
+			require.NoError(t, err)
+
+			msg := &Message{}
+			msg.AttachNewFile(tmpFile)
+
+			require.NotNil(t, msg.File)
+			assert.Equal(t, tmpFile.Name(), msg.File.Name())
+			assert.Equal(t, OtherFile, msg.ContentType)
+		})
+	}
+}
+
+func TestMessage_AttachExistingFile(t *testing.T) {
+	tests := []struct {
+		name   string
+		fileID string
+	}{
+		{
+			name:   "valid_file_id",
+			fileID: "file123",
+		},
+		{
+			name:   "empty_file_id",
+			fileID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &Message{}
+			msg.AttachExistingFile(tt.fileID)
+
+			assert.Equal(t, tt.fileID, msg.FileID)
+			assert.Equal(t, OtherFile, msg.ContentType)
+		})
+	}
+}
+
+func TestMessage_AttachNewVoice(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent string
+		fileName    string
+	}{
+		{
+			name:        "valid_voice_file",
+			fileContent: "voice content",
+			fileName:    "voice.ogg",
+		},
+		{
+			name:        "empty_voice_file",
+			fileContent: "",
+			fileName:    "empty.m4a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile, err := os.CreateTemp(tmpDir, tt.fileName)
+			t.Cleanup(func() {
+				err := tmpFile.Close()
+				assert.NoError(t, err)
+			})
+
+			require.NoError(t, err)
+
+			_, err = tmpFile.WriteString(tt.fileContent)
+			require.NoError(t, err)
+
+			msg := &Message{}
+			msg.AttachNewVoice(tmpFile)
+
+			require.NotNil(t, msg.File)
+			assert.Equal(t, tmpFile.Name(), msg.File.Name())
+			assert.Equal(t, Voice, msg.ContentType)
+
+		})
+	}
+}
+
+func TestMessage_AttachExistingVoice(t *testing.T) {
+	tests := []struct {
+		name   string
+		fileID string
+	}{
+		{
+			name:   "valid_voice_id",
+			fileID: "voice123",
+		},
+		{
+			name:   "empty_voice_id",
+			fileID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &Message{}
+			msg.AttachExistingVoice(tt.fileID)
+
+			assert.Equal(t, tt.fileID, msg.FileID)
+			assert.Equal(t, Voice, msg.ContentType)
+		})
+	}
+}
+
+func TestMessage_Send_WithNewFile(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "test.txt")
+	t.Cleanup(func() {
+		err := tmpFile.Close()
+		assert.NoError(t, err)
+	})
+
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString("test content")
+	require.NoError(t, err)
+
+	// Seek back to beginning for reading
+	_, err = tmpFile.Seek(0, 0)
+	require.NoError(t, err)
+
+	msg := &Message{
+		client:      &client,
+		Chat:        Chat{ID: "chat123"},
+		File:        NewUploadFileFromReader(tmpFile.Name(), tmpFile),
+		ContentType: OtherFile,
+	}
+
+	err = msg.Send()
+	assert.NoError(t, err)
+
+}
+
+func TestMessage_Send_WithExistingFile(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	msg := &Message{
+		client:      &client,
+		Chat:        Chat{ID: "chat123"},
+		FileID:      "file123",
+		ContentType: OtherFile,
+	}
+
+	err := msg.Send()
+	assert.NoError(t, err)
+}
+
+func TestMessage_Send_WithNewVoice(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "voice.ogg")
+	t.Cleanup(func() {
+		err := tmpFile.Close()
+		assert.NoError(t, err)
+	})
+
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString("voice content")
+	require.NoError(t, err)
+
+	// Seek back to beginning for reading
+	_, err = tmpFile.Seek(0, 0)
+	require.NoError(t, err)
+
+	msg := &Message{
+		client:      &client,
+		Chat:        Chat{ID: "chat123"},
+		File:        NewUploadFileFromReader(tmpFile.Name(), tmpFile),
+		ContentType: Voice,
+	}
+
+	err = msg.Send()
+	assert.NoError(t, err)
+
+}
+
+func TestMessage_Send_WithExistingVoice(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	msg := &Message{
+		client:      &client,
+		Chat:        Chat{ID: "chat123"},
+		FileID:      "voice123",
+		ContentType: Voice,
+	}
+
+	err := msg.Send()
+	assert.NoError(t, err)
+}
+
+func TestMessage_Send_UnknownContentType_AutoDetect(t *testing.T) {
+	tests := []struct {
+		name         string
+		fileID       string
+		expectedPath string
+	}{
+		{
+			name:         "voice_file_id_starts_with_I",
+			fileID:       "Ivoice123",
+			expectedPath: "/messages/sendVoice",
+		},
+		{
+			name:         "regular_file_id_does_not_start_with_I",
+			fileID:       "file123",
+			expectedPath: "/messages/sendFile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewApiMockClient(t)
+
+			msg := &Message{
+				client:      &client,
+				Chat:        Chat{ID: "chat123"},
+				FileID:      tt.fileID,
+				ContentType: Unknown,
+			}
+
+			err := msg.Send()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestMessage_Send_UnknownContentType_WithFile_Extension(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+	}{
+		{
+			name:     "aac_extension_detects_voice",
+			fileName: "voice.aac",
+		},
+		{
+			name:     "ogg_extension_detects_voice",
+			fileName: "voice.ogg",
+		},
+		{
+			name:     "m4a_extension_detects_voice",
+			fileName: "voice.m4a",
+		},
+		{
+			name:     "txt_extension_detects_file",
+			fileName: "file.txt",
+		},
+		{
+			name:     "pdf_extension_detects_file",
+			fileName: "file.pdf",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewApiMockClient(t)
+
+			reader := strings.NewReader("content")
+			msg := &Message{
+				client:      &client,
+				Chat:        Chat{ID: "chat123"},
+				File:        NewUploadFileFromReader(tt.fileName, reader),
+				ContentType: Unknown,
+			}
+
+			err := msg.Send()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestMessage_Send_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		message     *Message
+		expectedErr string
+	}{
+		{
+			name: "nil_client",
+			message: &Message{
+				Chat: Chat{ID: "chat123"},
+			},
+			expectedErr: "client is not inited",
+		},
+		{
+			name: "empty_chat_id",
+			message: &Message{
+				client:      &Client{},
+				ContentType: Text,
+				Text:        "test",
+			},
+			expectedErr: "message should have chat id",
+		},
+		{
+			name: "no_data",
+			message: &Message{
+				client:      &Client{},
+				Chat:        Chat{ID: "chat123"},
+				ContentType: Unknown,
+			},
+			expectedErr: "cannot send message or file without data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.message.Send()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestMessage_Send_TextMessage(t *testing.T) {
+	client := NewApiMockClient(t)
+
+	msg := &Message{
+		client:      &client,
+		Chat:        Chat{ID: "chat123"},
+		Text:        "test message",
+		ContentType: Text,
+	}
+
+	err := msg.Send()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Заменил использования os.File на интерфейс с методами, которые и так используются. Все старые вызове с os.File продолжат работать, но также появится возможность передавать в качестве файла и любую сущность, реализующую интерфейс Reader и предоставляющей имя, контента, которое оно вычитывает. 

Решение для https://github.com/mail-ru-im/bot-golang/issues/29